### PR TITLE
Anika rec request Index Pages Working

### DIFF
--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestEditPage.js
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestEditPage.js
@@ -1,5 +1,77 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import { useParams } from "react-router-dom";
+import RecommendationRequestForm from 'main/components/RecommendationRequests/RecommendationRequestForm';
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+
+export default function RecommendationRequestEditPage({storybook=false}) {
+    let { id } = useParams();
+
+    const { data: recommendationRequest, _error, _status } =
+        useBackend(
+            // Stryker disable next-line all : don't test internal caching of React Query
+            [`/api/recommendationrequest?id=${id}`],
+            {  // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+                method: "GET",
+                url: `/api/recommendationrequest`,
+                params: {
+                    id
+                }
+            }
+        );
+
+    const objectToAxiosPutParams = (recommendationRequest) => ({
+        url: "/api/recommendationrequest",
+        method: "PUT",
+        params: {
+            id: recommendationRequest.id,
+        },
+        data: {
+          requesterEmail: recommendationRequest.requesterEmail,
+          professorEmail: recommendationRequest.professorEmail,
+          explanation: recommendationRequest.explanation,
+          dateRequested: recommendationRequest.dateRequested,
+          dateNeeded: recommendationRequest.dateNeeded,
+          done: recommendationRequest.done
+         }
+    });
+
+    const onSuccess = (recommendationRequest) => {
+      toast(`RecommendationRequest Updated - id: ${recommendationRequest.id} requesterEmail: ${recommendationRequest.requesterEmail}`);
+  }
+
+  const mutation = useBackendMutation(
+      objectToAxiosPutParams,
+      { onSuccess },
+      // Stryker disable next-line all : hard to set up test for caching
+      [`/api/recommendationrequest?id=${id}`]
+  );
+
+  const { isSuccess } = mutation
+
+    const onSubmit = async (data) => {
+        mutation.mutate(data);
+    }
+
+    if (isSuccess && !storybook) {
+        return <Navigate to="/recommendationrequest" />
+    }
+
+    return (
+      <BasicLayout>
+          <div className="pt-2">
+              <h1>Edit RecommendationRequest</h1>
+              {
+                  recommendationRequest && <RecommendationRequestForm submitAction={onSubmit} buttonLabel={"Update"} initialContents={recommendationRequest} />
+              }
+          </div>
+      </BasicLayout>
+  )
+}
+
+/*import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
 import RecommendationRequestForm from "main/components/RecommendationRequests/RecommendationRequestForm";
 import { Navigate } from 'react-router-dom'
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
@@ -26,7 +98,7 @@ export default function RecommendationRequestEditPage({storybook=false}) {
     url: "/api/recommendationrequest",
     method: "PUT",
     params: {
-      id: recommendationrequest.id,
+      id: recommendationRequest.id,
     },
     data: {
       requesterEmail: recommendationRequest.requesterEmail,
@@ -39,7 +111,7 @@ export default function RecommendationRequestEditPage({storybook=false}) {
   });
 
   const onSuccess = (recommendationRequest) => {
-    toast(`RecommendationRequest Updated - id: ${recommendationRequest.id} name: ${recommendationRequest.name}`);
+    toast(`RecommendationRequest Updated - id: ${recommendationRequest.id} requesterEmail: ${recommendationRequest.requesterEmail}`);
   }
 
   const mutation = useBackendMutation(
@@ -71,3 +143,4 @@ export default function RecommendationRequestEditPage({storybook=false}) {
   )
 }
 
+*/

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestEditPage.js
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestEditPage.js
@@ -1,13 +1,73 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import RecommendationRequestForm from "main/components/RecommendationRequests/RecommendationRequestForm";
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function RecommendationRequestEditPage() {
+export default function RecommendationRequestEditPage({storybook=false}) {
+  let { id } = useParams();
 
-  // Stryker disable all : placeholder for future implementation
+  const { data: recommendationRequest, _error, _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      [`/api/recommendationrequest?id=${id}`],
+      {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+        method: "GET",
+        url: `/api/recommendationrequest`,
+        params: {
+          id
+        }
+      }
+    );
+
+
+  const objectToAxiosPutParams = (recommendationRequest) => ({
+    url: "/api/recommendationrequest",
+    method: "PUT",
+    params: {
+      id: recommendationrequest.id,
+    },
+    data: {
+      requesterEmail: recommendationRequest.requesterEmail,
+      professorEmail: recommendationRequest.professorEmail,
+      explanation: recommendationRequest.explanation,
+      dateRequested: recommendationRequest.dateRequested,
+      dateNeeded: recommendationRequest.dateNeeded,
+      done: recommendationRequest.done
+    }
+  });
+
+  const onSuccess = (recommendationRequest) => {
+    toast(`RecommendationRequest Updated - id: ${recommendationRequest.id} name: ${recommendationRequest.name}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/recommendationrequest?id=${id}`]
+  );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/recommendationrequest" />
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit RecommendationRequest</h1>
+        {
+          recommendationRequest && <RecommendationRequestForm initialContents={recommendationRequest} submitAction={onSubmit} buttonLabel="Update" />
+        }
       </div>
     </BasicLayout>
   )
 }
+

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestIndexPage.js
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestIndexPage.js
@@ -1,14 +1,43 @@
+import React from 'react'
+import { useBackend } from 'main/utils/useBackend';
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import RecommendationRequestsTable from 'main/components/RecommendationRequests/RecommendationRequestsTable';
+import { Button } from 'react-bootstrap';
+import { useCurrentUser , hasRole} from 'main/utils/currentUser';
 
 export default function RecommendationRequestIndexPage() {
 
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+        return (
+            <Button
+                variant="primary"
+                href="/recommendationrequest/create"
+                style={{ float: "right" }}
+            >
+                Create Recommendation Request 
+            </Button>
+        )
+    } 
+  }
+  
+  const { data: requests, error: _error, status: _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/recommendationrequest/all"],
+      { method: "GET", url: "/api/recommendationrequest/all" },
+      []
+    );
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p><a href="/recommendationrequest/create">Create</a></p>
-        <p><a href="/recommendationrequest/edit/1">Edit</a></p>
+        {createButton()}
+        <h1>Recommendation Requests</h1>
+        <RecommendationRequestsTable requests={requests} currentUser={currentUser} />
       </div>
     </BasicLayout>
   )

--- a/frontend/src/stories/pages/RecommendationRequests/RecommendationRequestEditPage.stories.js
+++ b/frontend/src/stories/pages/RecommendationRequests/RecommendationRequestEditPage.stories.js
@@ -1,0 +1,38 @@
+
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
+import { rest } from "msw";
+
+import RecommendationRequestEditPage from "main/pages/RecommendationRequest/RecommendationRequestEditPage";
+
+export default {
+    title: 'pages/RecommendationRequest/RecommendationRequestEditPage',
+    component: RecommendationRequestEditPage
+};
+
+const Template = () => <RecommendationRequestEditPage storybook={true}/>;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/recommendationrequest', (_req, res, ctx) => {
+            return res(ctx.json(recommendationRequestFixtures.threeRequests[0]));
+        }),
+        rest.put('/api/recommendationrequest', async (req, res, ctx) => {
+            var reqBody = await req.text();
+            window.alert("PUT: " + req.url + " and body: " + reqBody);
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ],
+}
+
+
+

--- a/frontend/src/stories/pages/RecommendationRequests/RecommendationRequestIndexPage.stories.js
+++ b/frontend/src/stories/pages/RecommendationRequests/RecommendationRequestIndexPage.stories.js
@@ -1,0 +1,66 @@
+
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
+import { rest } from "msw";
+
+import RecommendationRequestIndexPage from "main/pages/RecommendationRequest/RecommendationRequestIndexPage";
+
+export default {
+    title: 'pages/RecommendationRequest/RecommendationRequestIndexPage',
+    component: RecommendationRequestIndexPage
+};
+
+const Template = () => <RecommendationRequestIndexPage storybook={true}/>;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/recommendationrequest/all', (_req, res, ctx) => {
+            return res(ctx.json([]));
+        }),
+    ]
+}
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/recommendationrequest/all', (_req, res, ctx) => {
+            return res(ctx.json(recommendationRequestFixtures.threeRequests));
+        }),
+    ],
+}
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.adminUser));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/recommendationrequest/all', (_req, res, ctx) => {
+            return res(ctx.json(recommendationRequestFixtures.threeRequests));
+        }),
+        rest.delete('/api/recommendationrequest', (req, res, ctx) => {
+            window.alert("DELETE: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ],
+}

--- a/frontend/src/tests/pages/RecommendationRequests/RecommendationRequestEditPage.test.js
+++ b/frontend/src/tests/pages/RecommendationRequests/RecommendationRequestEditPage.test.js
@@ -7,7 +7,6 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-
 import mockConsole from "jest-mock-console";
 
 const mockToast = jest.fn();
@@ -60,7 +59,7 @@ describe("RecommendationRequestEditPage tests", () => {
                 </QueryClientProvider>
             );
             await screen.findByText("Edit RecommendationRequest");
-            expect(screen.queryByTestId("RecommendationRequestForm-requesterEmail")).not.toBeInTheDocument();
+            expect(screen.queryByTestId("RecommendationRequest-requesterEmail")).not.toBeInTheDocument();
             restoreConsole();
         });
     });
@@ -75,36 +74,27 @@ describe("RecommendationRequestEditPage tests", () => {
             axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
             axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
             axiosMock.onGet("/api/recommendationrequest", { params: { id: 17 } }).reply(200, {
-                id: 17,
+                id: 1,
                 requesterEmail: "klamar@ucsb.edu",
                 professorEmail: "agraham@ucsb.edu",
-                explanation: "BS/MS Degree",
-                dateRequested: "2022-02-02T00:00",
-                dateNeeded: "2022-05-02T00:00",
-                done: false
+                explanation: "Like That",
+                dateRequested: "2022-01-03T00:00",
+                dateNeeded: "2022-05-03T00:00",
+                done: true
             });
             axiosMock.onPut('/api/recommendationrequest').reply(200, {
-                id: "17",
-                requesterEmail: "jcole@ucsb.edu",
-                professorEmail: "mboomin@ucsb.edu",
-                explanation: "MS Degree",
-                dateRequested: "2022-03-02T00:00",
-                dateNeeded: "2022-06-02T00:00",
-                done: "false"
+                id: "1",
+                requesterEmail: "mboomin@ucsb.edu",
+                professorEmail: "jcole@ucsb.edu",
+                explanation: "7 Minute Drill",
+                dateRequested: "2022-06-03T00:00",
+                dateNeeded: "2022-10-03T00:00",
+                done: "true"
             });
         });
 
         const queryClient = new QueryClient();
-        test("renders without crashing", () => {
-            render(
-                <QueryClientProvider client={queryClient}>
-                    <MemoryRouter>
-                        <RecommendationRequestEditPage />
-                    </MemoryRouter>
-                </QueryClientProvider>
-            );
-        });
-
+    
         test("Is populated with the data provided", async () => {
 
             render(
@@ -115,25 +105,59 @@ describe("RecommendationRequestEditPage tests", () => {
                 </QueryClientProvider>
             );
 
-            await screen.findByTestId("RecommendationRequestForm-requesterEmail");
+            await screen.findByTestId("RecommendationRequestForm-id");
 
             const idField = screen.getByTestId("RecommendationRequestForm-id");
             const requesterEmailField = screen.getByTestId("RecommendationRequestForm-requesterEmail");
-        const professorEmailField = screen.getByTestId("RecommendationRequestForm-professorEmail");
-        const explanationField = screen.getByTestId("RecommendationRequestForm-explanation");
-        const dateRequestedField = screen.getByTestId("RecommendationRequestForm-dateRequested");
-        const dateNeededField = screen.getByTestId("RecommendationRequestForm-dateNeeded");
-        const doneField = screen.getByTestId("RecommendationRequestForm-done");
-        const submitButton = screen.getByTestId("RecommendationRequestForm-submit");
+            const professorEmailField = screen.getByTestId("RecommendationRequestForm-professorEmail");
+            const explanationField = screen.getByTestId("RecommendationRequestForm-explanation");
+            const dateRequestedField = screen.getByTestId("RecommendationRequestForm-dateRequested");
+            const dateNeededField = screen.getByTestId("RecommendationRequestForm-dateNeeded");
+            const doneField = screen.getByTestId("RecommendationRequestForm-done");
+            const submitButton = screen.getByTestId("RecommendationRequestForm-submit");
 
-            expect(idField).toHaveValue("17");
+            expect(idField).toBeInTheDocument();
+            expect(idField).toHaveValue("1");
+            expect(requesterEmailField).toBeInTheDocument();
             expect(requesterEmailField).toHaveValue("klamar@ucsb.edu");
+            expect(professorEmailField).toBeInTheDocument();
             expect(professorEmailField).toHaveValue("agraham@ucsb.edu");
-            expect(explanationField).toHaveValue("BS/MS Degree");
-            expect(dateRequestedField).toHaveValue("2022-02-02T00:00");
-            expect(dateNeededField).toHaveValue("2022-05-02T00:00");
-            expect(doneField).toHaveValue("false");
-            expect(submitButton).toBeInTheDocument();
+            expect(explanationField).toBeInTheDocument();
+            expect(explanationField).toHaveValue("Like That");
+            expect(dateRequestedField).toBeInTheDocument();
+            expect(dateRequestedField).toHaveValue("2022-01-03T00:00");
+            expect(dateNeededField).toBeInTheDocument();
+            expect(dateNeededField).toHaveValue("2022-05-03T00:00");
+            expect(doneField).toBeInTheDocument();
+            expect(doneField).toHaveValue("true");
+
+            expect(submitButton).toHaveTextContent("Update");
+            
+            fireEvent.change(requesterEmailField, { target: { value: 'mboomin@ucsb.edu' } });
+            fireEvent.change(professorEmailField, { target: { value: 'jcole@ucsb.edu' } });
+            fireEvent.change(explanationField, { target: { value: '7 Minute Drill' } });
+            fireEvent.change(dateRequestedField, { target: { value: '2022-06-03T00:00' } });
+            fireEvent.change(dateNeededField, { target: { value: '2022-10-03T00:00' } });
+            fireEvent.click(doneField);
+
+            fireEvent.click(submitButton);
+
+            await waitFor(() => expect(mockToast).toBeCalled());
+            expect(mockToast).toBeCalledWith("RecommendationRequest Updated - id: 1 requesterEmail: mboomin@ucsb.edu");
+            
+            expect(mockNavigate).toBeCalledWith({ "to": "/recommendationrequest" });
+
+            expect(axiosMock.history.put.length).toBe(1); // times called
+            expect(axiosMock.history.put[0].params).toEqual({ id: 1 });            
+            expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+                requesterEmail: "mboomin@ucsb.edu",
+                professorEmail: "jcole@ucsb.edu",
+                explanation: "7 Minute Drill",
+                dateRequested: "2022-06-03T00:00",
+                dateNeeded: "2022-10-03T00:00",
+                done: true
+            })); // posted object
+
         });
 
         test("Changes when you click Update", async () => {
@@ -146,55 +170,49 @@ describe("RecommendationRequestEditPage tests", () => {
                 </QueryClientProvider>
             );
 
-            await screen.findByTestId("RecommendationRequestForm-requesterEmail");
+            await screen.findByTestId("RecommendationRequestForm-id");
 
             const idField = screen.getByTestId("RecommendationRequestForm-id");
             const requesterEmailField = screen.getByTestId("RecommendationRequestForm-requesterEmail");
-        const professorEmailField = screen.getByTestId("RecommendationRequestForm-professorEmail");
-        const explanationField = screen.getByTestId("RecommendationRequestForm-explanation");
-        const dateRequestedField = screen.getByTestId("RecommendationRequestForm-dateRequested");
-        const dateNeededField = screen.getByTestId("RecommendationRequestForm-dateNeeded");
-        const doneField = screen.getByTestId("RecommendationRequestForm-done");
-        const submitButton = screen.getByTestId("RecommendationRequestForm-submit");
+            const professorEmailField = screen.getByTestId("RecommendationRequestForm-professorEmail");
+            const explanationField = screen.getByTestId("RecommendationRequestForm-explanation");
+            const dateRequestedField = screen.getByTestId("RecommendationRequestForm-dateRequested");
+            const dateNeededField = screen.getByTestId("RecommendationRequestForm-dateNeeded");
+            const doneField = screen.getByTestId("RecommendationRequestForm-done");
+            const submitButton = screen.getByTestId("RecommendationRequestForm-submit");
 
-        expect(idField).toHaveValue("17");
-        expect(requesterEmailField).toHaveValue("klamar@ucsb.edu");
-        expect(professorEmailField).toHaveValue("agraham@ucsb.edu");
-        expect(explanationField).toHaveValue("BS/MS Degree");
-        expect(dateRequestedField).toHaveValue("2022-02-02T00:00");
-        expect(dateNeededField).toHaveValue("2022-05-02T00:00");
-        expect(doneField).toHaveValue("false");
-        expect(submitButton).toBeInTheDocument();
+            expect(idField).toBeInTheDocument();
+            expect(idField).toHaveValue("1");
+            expect(requesterEmailField).toBeInTheDocument();
+            expect(requesterEmailField).toHaveValue("klamar@ucsb.edu");
+            expect(professorEmailField).toBeInTheDocument();
+            expect(professorEmailField).toHaveValue("agraham@ucsb.edu");
+            expect(explanationField).toBeInTheDocument();
+            expect(explanationField).toHaveValue("Like That");
+            expect(dateRequestedField).toBeInTheDocument();
+            expect(dateRequestedField).toHaveValue("2022-01-03T00:00");
+            expect(dateNeededField).toBeInTheDocument();
+            expect(dateNeededField).toHaveValue("2022-05-03T00:00");
+            expect(doneField).toBeInTheDocument();
+            expect(doneField).toHaveValue("true");
 
-
-            fireEvent.change(requesterEmailField, { target: { value: 'jcole@ucsb.edu' } })
-            fireEvent.change(professorEmailField, { target: { value: 'mboomin@ucsb.edu' } })
-            fireEvent.change(explanationField, { target: { value: 'MS Degree' } })
-            fireEvent.change(dateRequestedField, { target: { value: "2022-03-02T00:00" } })
-            fireEvent.change(dateNeededField, { target: { value: "2022-06-02T00:00" } })
-            fireEvent.change(doneField, { target: { value: 'false' } })
+            expect(submitButton).toHaveTextContent("Update");
+            
+            fireEvent.change(requesterEmailField, { target: { value: 'mboomin@ucsb.edu' } });
+            fireEvent.change(professorEmailField, { target: { value: 'jcole@ucsb.edu' } });
+            fireEvent.change(explanationField, { target: { value: '7 Minute Drill' } });
+            fireEvent.change(dateRequestedField, { target: { value: '2022-06-03T00:00' } });
+            fireEvent.change(dateNeededField, { target: { value: '2022-10-03T00:00' } });
+            fireEvent.click(doneField);
 
             fireEvent.click(submitButton);
 
+
             await waitFor(() => expect(mockToast).toBeCalled());
-            expect(mockToast).toBeCalledWith("RecommendationRequest Updated - id: 17 requesterEmail: jcole@ucsb.edu");
+            expect(mockToast).toBeCalledWith("RecommendationRequest Updated - id: 1 requesterEmail: mboomin@ucsb.edu");
             expect(mockNavigate).toBeCalledWith({ "to": "/recommendationrequest" });
-
-            expect(axiosMock.history.put.length).toBe(1); // times called
-            expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
-            expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
-                requesterEmail: "jcole@ucsb.edu",
-                professorEmail: "mboomin@ucsb.edu",
-                explanation: "MS Degree",
-                dateRequested: "2022-03-02T00:00",
-                dateNeeded: "2022-06-02T00:00",
-                done: 'false'
-            })); // posted object
-
         });
 
        
     });
 });
-
-

--- a/frontend/src/tests/pages/RecommendationRequests/RecommendationRequestEditPage.test.js
+++ b/frontend/src/tests/pages/RecommendationRequests/RecommendationRequestEditPage.test.js
@@ -1,44 +1,200 @@
-import { render, screen } from "@testing-library/react";
-import RecommendationRequestEditPage from "main/pages/RecommendationRequest/RecommendationRequestEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import RecommendationRequestEditPage from "main/pages/RecommendationRequest/RecommendationRequestEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            id: 17
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
 
 describe("RecommendationRequestEditPage tests", () => {
 
-    const axiosMock = new AxiosMockAdapter(axios);
+    describe("when the backend doesn't return data", () => {
 
-    const setupUserOnly = () => {
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+        const axiosMock = new AxiosMockAdapter(axios);
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/recommendationrequest", { params: { id: 17 } }).timeout();
+        });
 
-        setupUserOnly();
+        const queryClient = new QueryClient();
+        test("renders header but table is not present", async () => {
 
-        // act
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <RecommendationRequestEditPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
+            const restoreConsole = mockConsole();
 
-        // assert
-        expect(screen.getByText("Edit page not yet implemented")).toBeInTheDocument();
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RecommendationRequestEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+            await screen.findByText("Edit RecommendationRequest");
+            expect(screen.queryByTestId("RecommendationRequestForm-requesterEmail")).not.toBeInTheDocument();
+            restoreConsole();
+        });
     });
 
+    describe("tests where backend is working normally", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/recommendationrequest", { params: { id: 17 } }).reply(200, {
+                id: 17,
+                requesterEmail: "klamar@ucsb.edu",
+                professorEmail: "agraham@ucsb.edu",
+                explanation: "BS/MS Degree",
+                dateRequested: "2022-02-02T00:00",
+                dateNeeded: "2022-05-02T00:00",
+                done: false
+            });
+            axiosMock.onPut('/api/recommendationrequest').reply(200, {
+                id: "17",
+                requesterEmail: "jcole@ucsb.edu",
+                professorEmail: "mboomin@ucsb.edu",
+                explanation: "MS Degree",
+                dateRequested: "2022-03-02T00:00",
+                dateNeeded: "2022-06-02T00:00",
+                done: "false"
+            });
+        });
+
+        const queryClient = new QueryClient();
+        test("renders without crashing", () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RecommendationRequestEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+        });
+
+        test("Is populated with the data provided", async () => {
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RecommendationRequestEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await screen.findByTestId("RecommendationRequestForm-requesterEmail");
+
+            const idField = screen.getByTestId("RecommendationRequestForm-id");
+            const requesterEmailField = screen.getByTestId("RecommendationRequestForm-requesterEmail");
+        const professorEmailField = screen.getByTestId("RecommendationRequestForm-professorEmail");
+        const explanationField = screen.getByTestId("RecommendationRequestForm-explanation");
+        const dateRequestedField = screen.getByTestId("RecommendationRequestForm-dateRequested");
+        const dateNeededField = screen.getByTestId("RecommendationRequestForm-dateNeeded");
+        const doneField = screen.getByTestId("RecommendationRequestForm-done");
+        const submitButton = screen.getByTestId("RecommendationRequestForm-submit");
+
+            expect(idField).toHaveValue("17");
+            expect(requesterEmailField).toHaveValue("klamar@ucsb.edu");
+            expect(professorEmailField).toHaveValue("agraham@ucsb.edu");
+            expect(explanationField).toHaveValue("BS/MS Degree");
+            expect(dateRequestedField).toHaveValue("2022-02-02T00:00");
+            expect(dateNeededField).toHaveValue("2022-05-02T00:00");
+            expect(doneField).toHaveValue("false");
+            expect(submitButton).toBeInTheDocument();
+        });
+
+        test("Changes when you click Update", async () => {
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RecommendationRequestEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await screen.findByTestId("RecommendationRequestForm-requesterEmail");
+
+            const idField = screen.getByTestId("RecommendationRequestForm-id");
+            const requesterEmailField = screen.getByTestId("RecommendationRequestForm-requesterEmail");
+        const professorEmailField = screen.getByTestId("RecommendationRequestForm-professorEmail");
+        const explanationField = screen.getByTestId("RecommendationRequestForm-explanation");
+        const dateRequestedField = screen.getByTestId("RecommendationRequestForm-dateRequested");
+        const dateNeededField = screen.getByTestId("RecommendationRequestForm-dateNeeded");
+        const doneField = screen.getByTestId("RecommendationRequestForm-done");
+        const submitButton = screen.getByTestId("RecommendationRequestForm-submit");
+
+        expect(idField).toHaveValue("17");
+        expect(requesterEmailField).toHaveValue("klamar@ucsb.edu");
+        expect(professorEmailField).toHaveValue("agraham@ucsb.edu");
+        expect(explanationField).toHaveValue("BS/MS Degree");
+        expect(dateRequestedField).toHaveValue("2022-02-02T00:00");
+        expect(dateNeededField).toHaveValue("2022-05-02T00:00");
+        expect(doneField).toHaveValue("false");
+        expect(submitButton).toBeInTheDocument();
+
+
+            fireEvent.change(requesterEmailField, { target: { value: 'jcole@ucsb.edu' } })
+            fireEvent.change(professorEmailField, { target: { value: 'mboomin@ucsb.edu' } })
+            fireEvent.change(explanationField, { target: { value: 'MS Degree' } })
+            fireEvent.change(dateRequestedField, { target: { value: "2022-03-02T00:00" } })
+            fireEvent.change(dateNeededField, { target: { value: "2022-06-02T00:00" } })
+            fireEvent.change(doneField, { target: { value: 'false' } })
+
+            fireEvent.click(submitButton);
+
+            await waitFor(() => expect(mockToast).toBeCalled());
+            expect(mockToast).toBeCalledWith("RecommendationRequest Updated - id: 17 requesterEmail: jcole@ucsb.edu");
+            expect(mockNavigate).toBeCalledWith({ "to": "/recommendationrequest" });
+
+            expect(axiosMock.history.put.length).toBe(1); // times called
+            expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+            expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+                requesterEmail: "jcole@ucsb.edu",
+                professorEmail: "mboomin@ucsb.edu",
+                explanation: "MS Degree",
+                dateRequested: "2022-03-02T00:00",
+                dateNeeded: "2022-06-02T00:00",
+                done: 'false'
+            })); // posted object
+
+        });
+
+       
+    });
 });
 
 

--- a/frontend/src/tests/pages/RecommendationRequests/RecommendationRequestIndexPage.test.js
+++ b/frontend/src/tests/pages/RecommendationRequests/RecommendationRequestIndexPage.test.js
@@ -1,17 +1,32 @@
-import { render, screen } from "@testing-library/react";
-import RecommendationRequestIndexPage from "main/pages/RecommendationRequest/RecommendationRequestIndexPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import RecommendationRequestIndexPage from "main/pages/RecommendationRequest/RecommendationRequestIndexPage";
+
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
 
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
 
 describe("RecommendationRequestIndexPage tests", () => {
 
     const axiosMock = new AxiosMockAdapter(axios);
+
+    const testId = "RecommendationRequestsTable";
 
     const setupUserOnly = () => {
         axiosMock.reset();
@@ -20,11 +35,18 @@ describe("RecommendationRequestIndexPage tests", () => {
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
     };
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
 
-        setupUserOnly();
+    test("Renders with Create Button for admin user", async () => {
+        // arrange
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/recommendationrequest/all").reply(200, []);
 
         // act
         render(
@@ -36,9 +58,97 @@ describe("RecommendationRequestIndexPage tests", () => {
         );
 
         // assert
-        expect(screen.getByText("Index page not yet implemented")).toBeInTheDocument();
-        expect(screen.getByText("Create")).toBeInTheDocument();
-        expect(screen.getByText("Edit")).toBeInTheDocument();
+        await waitFor( ()=>{
+            expect(screen.getByText(/Create Recommendation Request/)).toBeInTheDocument();
+        });
+        const button = screen.getByText(/Create Recommendation Request/);
+        expect(button).toHaveAttribute("href", "/recommendationrequest/create");
+        expect(button).toHaveAttribute("style", "float: right;");
+    });
+
+    test("renders three dates correctly for regular user", async () => {
+        
+        // arrange
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/recommendationrequest/all").reply(200, recommendationRequestFixtures.threeRequests);
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RecommendationRequestIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+
+        // assert that the Create button is not present when user isn't an admin
+        expect(screen.queryByText(/Create Recommendation Request/)).not.toBeInTheDocument();
+
+    });
+
+
+    test("renders empty table when backend unavailable, user only", async () => {
+        // arrange
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/recommendationrequest/all").timeout();
+        const restoreConsole = mockConsole();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RecommendationRequestIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+
+        const errorMessage = console.error.mock.calls[0][0];
+        expect(errorMessage).toMatch("Error communicating with backend via GET on /api/recommendationrequest/all");
+        restoreConsole();
+
+        expect(screen.queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+    });
+
+    test("what happens when you click delete, admin", async () => {
+        // arrange
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/recommendationrequest/all").reply(200, recommendationRequestFixtures.threeRequests);
+        axiosMock.onDelete("/api/recommendationrequest").reply(200, "Recommendation Request with id 1 was deleted");
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RecommendationRequestIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+
+        const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
+
+        // act
+        fireEvent.click(deleteButton);
+
+        // assert
+        await waitFor(() => { expect(mockToast).toBeCalledWith("Recommendation Request with id 1 was deleted") });
+
     });
 
 });


### PR DESCRIPTION
Reccomendation Request now has a working delete button, it deletes from the table and on Swagger, same for the EDIT feature, and on Storybook the delete button is there (but there is no backend work in Storybook). It is passing all tests and coverage. 

Link to storybook: http://localhost:6006/?path=/story/pages-recommendationrequest-recommendationrequestindexpage--empty

Screenshot of new Index Page: 
![Screenshot 2024-05-12 182627](https://github.com/ucsb-cs156-s24/team03-s24-5pm-6/assets/91992504/389bef20-a7eb-46c9-a64f-98b4aeb77018)

Closes #32 